### PR TITLE
Agregar logs opcionales

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ end
 ```
 
 That log file will be then written with every resulting xml from each api call, both request and response.
+Note: Log level used is **info**.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ Transbank::Oneclick.configure do |config|
 end
 ```
 
+**Logging**
+
+Pass a logger object in the configuration pointing to a log file and any options you need:
+
+```ruby
+Transbank::Oneclick.configure do |config|
+  config.logger = Logger.new("RELATIVE_PATH_TO_LOG_FILE")
+end
+```
+
+That log file will be then written with every resulting xml from each api call, both request and response.
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/transbank-oneclick/fork )

--- a/lib/transbank/oneclick/configuration.rb
+++ b/lib/transbank/oneclick/configuration.rb
@@ -7,6 +7,7 @@ module Transbank
       attr_accessor :server_cert_path
       attr_accessor :rescue_exceptions
       attr_accessor :http_options
+      attr_accessor :logger
 
       def initialize
         self.rescue_exceptions = [Net::ReadTimeout, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadGateway,

--- a/lib/transbank/oneclick/request.rb
+++ b/lib/transbank/oneclick/request.rb
@@ -12,6 +12,13 @@ module Transbank
         self.action = action
         self.rescue_exceptions = opt[:rescue_exceptions]
         self.xml = Document.new(action, params)
+
+        logger = Transbank::Oneclick.configuration.logger
+        if logger
+          logger.info "Transbank #{action} request"
+          logger.info xml.doc.to_s
+        end
+
         self.client = Client.new opt.delete(:http_options)
       end
 

--- a/lib/transbank/oneclick/response.rb
+++ b/lib/transbank/oneclick/response.rb
@@ -29,6 +29,13 @@ module Transbank
         self.action = action
         self.attributes = Hash[*xml_result.map{|e| [e.name.underscore.to_sym, e.text]}.flatten]
         self.errors = []
+
+        logger = Transbank::Oneclick.configuration.logger
+        if logger
+          logger.info "Transbank #{action} response"
+          logger.info doc.to_s
+        end
+
         validate!
       end
 


### PR DESCRIPTION
Para la fase de certificación de transbank me están pidiendo logs no solo de la respuesta sino del request como tal. Se me hace útil poder pasarle un objeto `Logger` que se pueda usar para sacar esos xmls directo a un archivo que sea fácil de enviar, me ha pasado también en el pasado que cuando pides soporte te piden el xml entero. 

Lo dejo acá porque puede serle útil a otro que use esta gema, que hasta ahora me está funcionando bien. 
